### PR TITLE
🐛 Prevent Auto Serialization from Converting Bytes to JSON

### DIFF
--- a/app/src/main/java/kr/co/langquence/data/remote/CorrectApi.kt
+++ b/app/src/main/java/kr/co/langquence/data/remote/CorrectApi.kt
@@ -1,19 +1,20 @@
 package kr.co.langquence.data.remote
 
 import kr.co.langquence.data.dto.response.CorrectResponse
+import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface CorrectApi {
-	private companion object {
-		const val CORRECT_API_URL: String = "correct"
-	}
+    private companion object {
+        const val CORRECT_API_URL: String = "correct"
+    }
 
-	@POST(CORRECT_API_URL)
-	@Headers(
-		"Content-Type: application/octet-stream",
-		"Accept: application/json"
-	)
-	suspend fun request(@Body request: ByteArray): CorrectResponse
+    @POST(CORRECT_API_URL)
+    @Headers(
+        "Content-Type: application/octet-stream",
+        "Accept: application/json"
+    )
+    suspend fun request(@Body request: RequestBody): CorrectResponse
 }

--- a/app/src/main/java/kr/co/langquence/data/repository/CorrectRepositoryImpl.kt
+++ b/app/src/main/java/kr/co/langquence/data/repository/CorrectRepositoryImpl.kt
@@ -3,10 +3,16 @@ package kr.co.langquence.data.repository
 import kr.co.langquence.data.remote.CorrectApi
 import kr.co.langquence.model.domain.CorrectAnswer
 import kr.co.langquence.model.repository.CorrectRepository
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
 
 class CorrectRepositoryImpl @Inject constructor(
-	private val api: CorrectApi
-): CorrectRepository {
-	override suspend fun request(body: ByteArray): CorrectAnswer = api.request(body).toEntity()
+    private val api: CorrectApi
+) : CorrectRepository {
+    override suspend fun request(body: ByteArray): CorrectAnswer {
+        val requestBody = body.toRequestBody("application/octet-stream".toMediaTypeOrNull())
+
+        return api.request(requestBody).toEntity()
+    }
 }


### PR DESCRIPTION
## Reason for Work
Fix the issue where the client sends a byte array as JSON.

<br/>

## Tasks
```kotlin
val requestBody = body.toRequestBody("application/octet-stream".toMediaTypeOrNull())
```

This was a very simple issue—I just changed `byteArray` to `byteArray.toRequestBody()`.  
This prevents `OkHttp` from converting `bytes` to `JSON`.

![image](https://github.com/user-attachments/assets/f56d77d7-0fe9-4406-bdae-f0e3c8915b9a)


<br/>

## Issues
- none
